### PR TITLE
Add SpeakApi & refactor named pipe messages to use a binary format.

### DIFF
--- a/windows/Sources/FabricSandbox/StringSubSequence+Trimmed.swift
+++ b/windows/Sources/FabricSandbox/StringSubSequence+Trimmed.swift
@@ -1,4 +1,10 @@
-extension String.SubSequence {
+public extension String.SubSequence {
+    func trimmed() -> String {
+        return String(self).trimmed()
+    }
+}
+
+public extension String {
     func trimmed() -> String {
         return String(
             self.drop(while: { $0.isWhitespace })

--- a/windows/Sources/Runtime/Runtime.swift
+++ b/windows/Sources/Runtime/Runtime.swift
@@ -34,6 +34,14 @@ public func setCursorPos(x: Int32, y: Int32) {
   sendMessage(.setCursorPos(Pos(x: x, y: y)))
 }
 
+public func speak(text: String, flags: UInt32) {
+  sendMessage(.speak(Speak(text: text, flags: flags)))
+}
+
+public func speakSkip() {
+  sendMessage(.speakSkip)
+}
+
 public func processDetach() {
   // Disconnect and close the pipe client
   pipeClient = nil
@@ -58,7 +66,7 @@ func sendMessage(_ message: PipeMessages) {
   }
 
   do {
-    try pipeClient.send(message.toString())
+    try pipeClient.sendBytes(message.toBytes())
   } catch {
     fatalError("Failed to send pipe message")
   }

--- a/windows/Sources/Shared/PipeMessages.swift
+++ b/windows/Sources/Shared/PipeMessages.swift
@@ -1,3 +1,5 @@
+import WinSDK
+
 public struct Pos {
   public var x: Int32
   public var y: Int32
@@ -22,53 +24,211 @@ public struct Rect {
   }
 }
 
+public struct Speak {
+  public var text: String
+  public var flags: UInt32
+
+  public init(text: String, flags: UInt32) {
+    self.text = text
+    self.flags = flags
+  }
+}
+
 public enum PipeMessages {
   case exit
   case clipCursor(Rect)
   case setCursorPos(Pos)
+  case speak(Speak)
+  case speakSkip
 
-  // Convert the message from a cvs string
-  public static func fromString(_ message: String) -> PipeMessages? {
-    let csv = message.split(separator: ",")
-    guard csv.count > 1 else {
+  private var rawValue: UInt8 {
+    switch self {
+    case .exit: return 0
+    case .clipCursor: return 1
+    case .setCursorPos: return 2
+    case .speak: return 3
+    case .speakSkip: return 4
+    }
+  }
+
+  // Convert the message from a byte array
+  public static func fromBytes(_ bytes: [UInt16]) -> PipeMessages? {
+    guard bytes.count >= 1 else {
       return nil
     }
 
-    switch csv[0] {
-    case "exit":
+    let buffer = ByteBuffer(data: bytes)
+    let type = buffer.readUInt8()!
+
+    switch type {
+    case 0:
       return .exit
-    case "clipCursor":
-      guard csv.count == 5,
-        let left = Int32(csv[1]),
-        let top = Int32(csv[2]),
-        let right = Int32(csv[3]),
-        let bottom = Int32(csv[4])
-      else {
+    case 1:
+      let left = buffer.readInt32()
+      let top = buffer.readInt32()
+      let right = buffer.readInt32()
+      let bottom = buffer.readInt32()
+      guard let left = left, let top = top, let right = right, let bottom = bottom else {
         return nil
       }
-      return .clipCursor(Rect(left: left, top: top, right: right, bottom: bottom))
-    case "setCursorPos":
-      guard csv.count == 3,
-        let x = Int32(csv[1]),
-        let y = Int32(csv[2])
-      else {
+      return .clipCursor(Rect(
+        left: left,
+        top: top,
+        right: right,
+        bottom: bottom
+      ))
+    case 2:
+      let x = buffer.readInt32()
+      let y = buffer.readInt32()
+      guard let x = x, let y = y else {
         return nil
       }
-      return .setCursorPos(Pos(x: x, y: y))
+      return .setCursorPos(Pos(
+        x: x,
+        y: y
+      ))
+    case 3:
+      let text = buffer.readString()
+      let flags = buffer.readUInt32()
+      guard let text = text, let flags = flags else {
+        return nil
+      }
+      return .speak(Speak(
+        text: text,
+        flags: flags
+      ))
+    case 4:
+      return .speakSkip
     default:
       return nil
     }
   }
 
-  // Convert the message to a csv string
-  public func toString() -> String {
+  // Convert the message to a byte array
+  // The first byte is the message type, the rest is the message data
+  public func toBytes() -> [UInt16] {
+    let buffer = ByteBuffer()
+    buffer.appendUInt8(rawValue)
+
     switch self {
     case .exit:
-      return "exit"
+      break
     case .clipCursor(let rect):
-      return "clipCursor,\(rect.left),\(rect.top),\(rect.right),\(rect.bottom)"
+      buffer.appendInt32(rect.left)
+      buffer.appendInt32(rect.top)
+      buffer.appendInt32(rect.right)
+      buffer.appendInt32(rect.bottom)
     case .setCursorPos(let pos):
-      return "setCursorPos,\(pos.x),\(pos.y)"
+      buffer.appendInt32(pos.x)
+      buffer.appendInt32(pos.y)
+    case .speak(let speak):
+      buffer.appendString(speak.text)
+      buffer.appendUInt32(speak.flags)
+    case .speakSkip:
+      break
     }
+    return buffer.data
+  }
+}
+
+private class ByteBuffer {
+  var data: [UInt16]
+
+  init() {
+    data = []
+  }
+
+  init(data: [UInt16]) {
+    self.data = data
+  }
+
+  var size : Int {
+    return data.count
+  }
+
+  func appendUInt8(_ value: UInt8) {
+    data.append(UInt16(value))
+  }
+
+  func appendUInt(_ value: UInt) {
+    appendUInt8(UInt8(value & 0xFF))
+    appendUInt8(UInt8((value >> 8) & 0xFF))
+  }
+
+  func appendInt(_ value: Int) {
+    appendUInt(UInt(bitPattern: value))
+  }
+
+  func appendUInt32(_ value: UInt32) {
+    appendUInt8(UInt8(value & 0xFF))
+    appendUInt8(UInt8((value >> 8) & 0xFF))
+    appendUInt8(UInt8((value >> 16) & 0xFF))
+    appendUInt8(UInt8((value >> 24) & 0xFF))
+  }
+
+  func appendInt32(_ value: Int32) {
+    appendUInt32(UInt32(bitPattern: value))
+  }
+
+  func appendString(_ string: String) {
+    appendInt(string.utf8.count)
+    data.append(contentsOf: string.utf16)
+  }
+
+  func readUInt8() -> UInt8? {
+    guard !data.isEmpty else {
+      return nil
+    }
+    let value = data[0]
+    data.removeFirst()
+    return UInt8(value)
+  }
+
+  func readUInt() -> UInt? {
+    let one = readUInt8()
+    let two = readUInt8()
+    guard let one = one, let two = two else {
+      return nil
+    }
+    return UInt(one) | UInt(two) << 8
+  }
+
+  func readInt() -> Int? {
+    guard let value = readUInt() else {
+      return nil
+    }
+    return Int(bitPattern: value)
+  }
+
+  func readUInt32() -> UInt32? {
+    let one = readUInt8()
+    let two = readUInt8()
+    let three = readUInt8()
+    let four = readUInt8()
+    guard let one = one, let two = two, let three = three, let four = four else {
+      return nil
+    }
+    return UInt32(one) | UInt32(two) << 8 | UInt32(three) << 16 | UInt32(four) << 24
+  }
+
+  func readInt32() -> Int32? {
+    guard let value = readUInt32() else {
+      return nil
+    }
+    return Int32(bitPattern: value)
+  }
+
+  func readString() -> String? {
+    guard let length = readInt() else {
+      return nil
+    }
+
+    guard data.count >= length else {
+      return nil
+    }
+
+    let string = String(decoding: data[0..<Int(length)], as: UTF16.self)
+    data.removeFirst(Int(length))
+    return string
   }
 }

--- a/windows/Sources/WinSDKExtras/SpeakApi.cpp
+++ b/windows/Sources/WinSDKExtras/SpeakApi.cpp
@@ -1,0 +1,39 @@
+#include "SpeakApi.h"
+
+#include <atlbase.h>
+#include <atlconv.h>
+#include <sapi.h>
+
+#include <iostream>
+
+class SpeakApi::Impl {
+    public:
+    Impl() {
+        auto result = spVoice.CoCreateInstance(CLSID_SpVoice);
+        if (!SUCCEEDED(result)) {
+            std::cout << "Failed to create ISpVoice instance" << std::endl;
+            throw std::runtime_error("Failed to create ISpVoice instance");
+        }
+    }
+
+    CComPtr<ISpVoice> spVoice;
+};
+
+SpeakApi::SpeakApi(): pImpl{std::make_shared<Impl>()} {
+}
+
+SpeakApi::~SpeakApi() {
+}
+
+SpeakApi::SpeakApi(const SpeakApi& other): pImpl{other.pImpl} {
+    std::cout << "Copy constructor" << std::endl;
+}
+
+HRESULT SpeakApi::Speak(std::string text, DWORD dwFlags) {
+    CA2W textw(text.c_str());
+    return pImpl->spVoice->Speak(textw, dwFlags, NULL);
+}
+
+HRESULT SpeakApi::Skip() {
+    return pImpl->spVoice->Skip(L"Sentence", 0x7fffffff, NULL);
+}

--- a/windows/Sources/WinSDKExtras/SpeakApi.cpp
+++ b/windows/Sources/WinSDKExtras/SpeakApi.cpp
@@ -3,15 +3,13 @@
 #include <atlbase.h>
 #include <atlconv.h>
 #include <sapi.h>
-
-#include <iostream>
+#include <stdexcept>
 
 class SpeakApi::Impl {
     public:
     Impl() {
         auto result = spVoice.CoCreateInstance(CLSID_SpVoice);
         if (!SUCCEEDED(result)) {
-            std::cout << "Failed to create ISpVoice instance" << std::endl;
             throw std::runtime_error("Failed to create ISpVoice instance");
         }
     }
@@ -26,7 +24,6 @@ SpeakApi::~SpeakApi() {
 }
 
 SpeakApi::SpeakApi(const SpeakApi& other): pImpl{other.pImpl} {
-    std::cout << "Copy constructor" << std::endl;
 }
 
 HRESULT SpeakApi::Speak(std::string text, DWORD dwFlags) {

--- a/windows/Sources/WinSDKExtras/include/SpeakApi.h
+++ b/windows/Sources/WinSDKExtras/include/SpeakApi.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+#include <windows.h>
+#include <memory>
+
+class SpeakApi {
+    public:
+    SpeakApi();
+    ~SpeakApi();
+    SpeakApi(const SpeakApi& other);
+
+    public:
+    HRESULT Speak(std::string text, DWORD dwFlags);
+    HRESULT Skip();
+
+    private:
+    // Pointer to implementation idiom, with a shared pointer so the object can be copied by swift
+    class Impl; std::shared_ptr<Impl> pImpl;
+};

--- a/windows/Sources/WinSDKExtras/include/module.modulemap
+++ b/windows/Sources/WinSDKExtras/include/module.modulemap
@@ -1,4 +1,5 @@
 module WinSDKExtras {
     header "WinSDKExtras.h"
+    header "SpeakApi.h"
     export *
 }

--- a/windows/Tests/IntergrationTests.swift
+++ b/windows/Tests/IntergrationTests.swift
@@ -82,6 +82,8 @@ import WindowsUtils
     server.waitForNextMessage()
 
     let receivedMessage = server.lastMessage ?? ""
+    print("Received message: \(receivedMessage.count)")
+    print("Expected message: \("Hello, World!".count)")
     #expect(receivedMessage == "Hello, World!")
   }
 
@@ -186,14 +188,7 @@ class TestOutputConsumer: OutputConsumer {
   }
 
   func trimmed() -> String {
-    // Remove leading and trailing whitespace without using Foundation
-    return String(
-      output
-        .drop(while: { $0.isWhitespace })
-        .reversed()
-        .drop(while: { $0.isWhitespace })
-        .reversed()
-    )
+    return output.trimmed()
   }
 }
 private func findSwiftRuntimeDirectory() throws -> File {

--- a/windows/Tests/NamedPipeTests.swift
+++ b/windows/Tests/NamedPipeTests.swift
@@ -1,6 +1,7 @@
 @_spi(Experimental) import Testing
 import WinSDK
 import WindowsUtils
+import FabricSandbox
 
 @Suite struct NamedPipeTests {
   @Test func namedPipe() throws {
@@ -29,7 +30,8 @@ class TestNamedPipeServer: NamedPipeServer {
     try super.init(pipeName: self.pipeName)
   }
 
-  override func onMessage(_ message: String) -> Bool {
+  override func onMessage(_ data: [UInt16]) -> Bool {
+    let message = String(decodingCString: data, as: UTF16.self).trimmed()
     if message == "exit" {
       return true
     }

--- a/windows/Tests/PipeMessagesTests.swift
+++ b/windows/Tests/PipeMessagesTests.swift
@@ -1,0 +1,60 @@
+import Testing
+import Shared
+
+struct PipeMessagesTests {
+    @Test func exit() {
+        let bytes = PipeMessages.exit.toBytes()
+        let message = PipeMessages.fromBytes(bytes)!
+        guard case .exit = message else {
+            Issue.record("Expected .exit, got \(message)")
+            return
+        }
+    }
+
+    @Test func clipCursor() {
+        let rect = Rect(left: 1, top: 2, right: 3, bottom: 4)
+        let bytes = PipeMessages.clipCursor(rect).toBytes()
+        let message = PipeMessages.fromBytes(bytes)!
+        guard case let .clipCursor(messageRect) = message else {
+            Issue.record("Expected .clipCursor, got \(message)")
+            return
+        }
+        #expect(messageRect.left == 1)
+        #expect(messageRect.top == 2)
+        #expect(messageRect.right == 3)
+        #expect(messageRect.bottom == 4)
+    }
+
+    @Test func setCursorPos() {
+        let pos = Pos(x: 1, y: 2)
+        let bytes = PipeMessages.setCursorPos(pos).toBytes()
+        let message = PipeMessages.fromBytes(bytes)!
+        guard case let .setCursorPos(messagePos) = message else {
+            Issue.record("Expected .setCursorPos, got \(message)")
+            return
+        }
+        #expect(messagePos.x == 1)
+        #expect(messagePos.y == 2)
+    }
+
+    @Test func speak() {
+        let speak = Speak(text: "Hello, world!", flags: 1)
+        let bytes = PipeMessages.speak(speak).toBytes()
+        let message = PipeMessages.fromBytes(bytes)!
+        guard case let .speak(messageSpeak) = message else {
+            Issue.record("Expected .speak, got \(message)")
+            return
+        }
+        #expect(messageSpeak.text == "Hello, world!")
+        #expect(messageSpeak.flags == 1)
+    }
+
+    @Test func speakSkip() {
+        let bytes = PipeMessages.speakSkip.toBytes()
+        let message = PipeMessages.fromBytes(bytes)!
+        guard case .speakSkip = message else {
+            Issue.record("Expected .speakSkip, got \(message)")
+            return
+        }
+    }
+}


### PR DESCRIPTION
SpeakAPI provides a way to use `ISpVoice` from swift
Pipe messages are a biniary format, CSV was not suitable for user provided strings.
Add pipe messages for the SpeakAPI, hooks will be added in a seperate PR.