### PR TITLE
Improve and test ACL code

### DIFF
--- a/windows/Sources/FabricSandbox/FabricSandbox.swift
+++ b/windows/Sources/FabricSandbox/FabricSandbox.swift
@@ -149,8 +149,8 @@ class FabricSandbox {
       pipeName: "\\\\.\\pipe\\FabricSandbox" + randomString(length: 10))
 
     // Grant access to the named pipe
-    try grantNamedPipeAccess(
-      pipe: namedPipeServer, trustee: container,
+    try grantAccess(
+      namedPipeServer, trustee: container,
       accessPermissions: [.genericRead, .genericWrite])
 
     let args = try commandLine.getSandboxArgs(

--- a/windows/Sources/FabricSandbox/FabricSandbox.swift
+++ b/windows/Sources/FabricSandbox/FabricSandbox.swift
@@ -106,42 +106,42 @@ class FabricSandbox {
 
       // Grant full access to the mounted disk
       try grantAccess(
-        sandboxRoot, appContainer: container,
+        sandboxRoot, trustee: container,
         accessPermissions: [.genericAll])
 
       if let assetsDir = commandLine.getAssetsDir(), isDevEnv {
         // Grant read access to the assets dir in dev
         try grantAccess(
-          assetsDir, appContainer: container,
+          assetsDir, trustee: container,
           accessPermissions: [.genericRead])
       }
 
       if let log4jConfig = commandLine.getJvmProp("log4j.configurationFile") {
         // Grant read access to the log4j configuration file
         try grantAccess(
-          File(log4jConfig), appContainer: container,
+          File(log4jConfig), trustee: container,
           accessPermissions: [.genericRead])
       }
     } else {
       logger.debug("Working directory is not root, granting access")
       // Grant read and execute to .minecraft
       try grantAccess(
-        sandboxRoot, appContainer: container,
+        sandboxRoot, trustee: container,
         accessPermissions: [.genericRead, .genericExecute])
 
       // Grant full access to the working directory
       try grantAccess(
-        sandboxWorkingDirectory, appContainer: container,
+        sandboxWorkingDirectory, trustee: container,
         accessPermissions: [.genericAll])
 
       try grantAccess(
-        tempDir, appContainer: container,
+        tempDir, trustee: container,
         accessPermissions: [.genericAll])
     }
 
     // Grant read and execute to Java home
     try grantAccess(
-      javaDirectory, appContainer: container,
+      javaDirectory, trustee: container,
       accessPermissions: [.genericRead, .genericExecute])
 
     // Create a named pipe server for IPC with the sandboxed process
@@ -150,7 +150,7 @@ class FabricSandbox {
 
     // Grant access to the named pipe
     try grantNamedPipeAccess(
-      pipe: namedPipeServer, appContainer: container,
+      pipe: namedPipeServer, trustee: container,
       accessPermissions: [.genericRead, .genericWrite])
 
     let args = try commandLine.getSandboxArgs(

--- a/windows/Sources/Sandbox/AppContainer.swift
+++ b/windows/Sources/Sandbox/AppContainer.swift
@@ -2,9 +2,10 @@ import WinSDK
 import WinSDKExtras
 import WindowsUtils
 
-public class AppContainer {
+public class AppContainer: Trustee {
   public let name: String
   public let sid: Sid
+  public let trustee: TRUSTEE_W
   let attributes: [SidAndAttributes]
   // Less Privileged App Container
   let lpac: Bool
@@ -18,6 +19,13 @@ public class AppContainer {
     self.attributes = attributes
     self.lpac = lpac
     self.mutex = mutex
+    self.trustee = TRUSTEE_W(
+      pMultipleTrustee: nil,
+      MultipleTrusteeOperation: NO_MULTIPLE_TRUSTEE,
+      TrusteeForm: TRUSTEE_IS_SID,
+      TrusteeType: TRUSTEE_IS_WELL_KNOWN_GROUP,
+      ptstrName: _CASTSID(sid.value)
+    )
   }
 
   deinit {

--- a/windows/Sources/WindowsUtils/Acl.swift
+++ b/windows/Sources/WindowsUtils/Acl.swift
@@ -195,6 +195,22 @@ public protocol Trustee {
   var trustee: TRUSTEE_W { get }
 }
 
+public class WellKnownTrustee: Trustee {
+    public let sid: Sid
+    public let trustee: TRUSTEE_W
+
+    public init(sid: String) throws {
+        self.sid = try Sid(sid)
+        self.trustee = TRUSTEE_W(
+            pMultipleTrustee: nil,
+            MultipleTrusteeOperation: NO_MULTIPLE_TRUSTEE,
+            TrusteeForm: TRUSTEE_IS_SID,
+            TrusteeType: TRUSTEE_IS_WELL_KNOWN_GROUP,
+            ptstrName: _CASTSID(self.sid.value)
+        )
+    }
+}
+
 public protocol SecurityObject {
   func getACL() throws -> PACL
   func setACL(acl: PACL, accessMode: AccessMode) throws

--- a/windows/Sources/WindowsUtils/Acl.swift
+++ b/windows/Sources/WindowsUtils/Acl.swift
@@ -159,13 +159,7 @@ public func grantNamedPipeAccess(
     grfAccessPermissions: accessPermissions.reduce(0) { $0 | $1.rawValue },
     grfAccessMode: GRANT_ACCESS,
     grfInheritance: DWORD(OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE),
-    Trustee: TRUSTEE_W(
-      pMultipleTrustee: nil,
-      MultipleTrusteeOperation: NO_MULTIPLE_TRUSTEE,
-      TrusteeForm: TRUSTEE_IS_SID,
-      TrusteeType: TRUSTEE_IS_WELL_KNOWN_GROUP,
-      ptstrName: _CASTSID(trustee.sid.value)
-    )
+    Trustee: trustee.trustee
   )
 
   // Add an entry to the ACL that grants the app container the specified access permissions

--- a/windows/Sources/WindowsUtils/Sid.swift
+++ b/windows/Sources/WindowsUtils/Sid.swift
@@ -8,6 +8,15 @@ public class Sid: CustomStringConvertible {
     self.value = sid
   }
 
+  public init(_ str: String) throws {
+    var sid: PSID? = nil
+    guard ConvertStringSidToSidW(str.wide, &sid), let sid = sid else {
+      throw Win32Error("ConvertStringSidToSidW")
+    }
+
+    self.value = sid
+  }
+
   public static func createWellKnown(_ type: WELL_KNOWN_SID_TYPE) throws -> Sid {
     var size = DWORD(_SECURITY_MAX_SID_SIZE())
     let sid: PSID = HeapAlloc(GetProcessHeap(), DWORD(HEAP_ZERO_MEMORY), SIZE_T(size))!

--- a/windows/Sources/WindowsUtils/Sid.swift
+++ b/windows/Sources/WindowsUtils/Sid.swift
@@ -1,15 +1,14 @@
 import WinSDK
 import WinSDKExtras
-import WindowsUtils
 
 public class Sid: CustomStringConvertible {
-  var value: PSID
+  public var value: PSID
 
-  init(_ sid: PSID) {
+  public init(_ sid: PSID) {
     self.value = sid
   }
 
-  static func createWellKnown(_ type: WELL_KNOWN_SID_TYPE) throws -> Sid {
+  public static func createWellKnown(_ type: WELL_KNOWN_SID_TYPE) throws -> Sid {
     var size = DWORD(_SECURITY_MAX_SID_SIZE())
     let sid: PSID = HeapAlloc(GetProcessHeap(), DWORD(HEAP_ZERO_MEMORY), SIZE_T(size))!
     var result = CreateWellKnownSid(type, nil, sid, &size)
@@ -76,16 +75,16 @@ public class Sid: CustomStringConvertible {
   }
 }
 
-class SidAndAttributes {
-  let sid: Sid
-  let sidAttributes: SID_AND_ATTRIBUTES
+public class SidAndAttributes {
+  public let sid: Sid
+  public let sidAttributes: SID_AND_ATTRIBUTES
 
-  init(sid: Sid) {
+  public init(sid: Sid) {
     self.sid = sid
     self.sidAttributes = SID_AND_ATTRIBUTES(Sid: sid.value, Attributes: DWORD(SE_GROUP_ENABLED))
   }
 
-  static func createWithCapability(type: SidCapability) throws -> SidAndAttributes {
+  public static func createWithCapability(type: SidCapability) throws -> SidAndAttributes {
     let sid =
       switch type {
       case .wellKnown(let wellKnownType):

--- a/windows/Tests/AclTests.swift
+++ b/windows/Tests/AclTests.swift
@@ -1,0 +1,38 @@
+import Testing
+import WinSDK
+import WindowsUtils
+
+struct AclTests {
+    @Test func testAcl() throws {
+    let tempDir = try createTempDir()
+    defer {
+      try! tempDir.delete()
+    }
+
+    let trustee = try WellKnownTrustee(sid: "S-1-5-21-3456789012-2345678901-1234567890-1234")
+    let sid = trustee.sid.description
+
+    var sddl = try getStringSecurityDescriptor(tempDir)
+    #expect(!sddl.contains(";\(sid)"))
+
+    try grantAccess(tempDir, trustee: trustee, accessPermissions: [.genericAll])
+    sddl = try getStringSecurityDescriptor(tempDir)
+    // Allow full access
+    #expect(sddl.contains("A;;FA;;;\(sid)"))
+
+    try clearAccess(tempDir, trustee: trustee)
+    sddl = try getStringSecurityDescriptor(tempDir)
+    #expect(!sddl.contains(";\(sid)"))
+
+    try denyAccess(tempDir, trustee: trustee, accessPermissions: [.genericExecute])
+    sddl = try getStringSecurityDescriptor(tempDir)
+    // Deny execute
+    #expect(sddl.contains("D;;FX;;;\(sid)"))
+
+    // Test that we can remove mutlipe ACEs
+    try grantAccess(tempDir, trustee: trustee, accessPermissions: [.genericRead])
+    try clearAccess(tempDir, trustee: trustee)
+    sddl = try getStringSecurityDescriptor(tempDir)
+    #expect(!sddl.contains(";\(sid)"))
+  }
+}

--- a/windows/Tests/AppContainerTests.swift
+++ b/windows/Tests/AppContainerTests.swift
@@ -1,6 +1,7 @@
 import Sandbox
 import Testing
 import WinSDK
+import WindowsUtils
 
 @testable import FabricSandbox
 
@@ -43,6 +44,6 @@ import WinSDK
       name: "TestContainer", description: "Test Container", capabilities: [])
     print("SID: '\(container.sid)'")
 
-    try grantAccess(tempDir, appContainer: container, accessPermissions: [.genericAll])
+    try grantAccess(tempDir, trustee: container, accessPermissions: [.genericAll])
   }
 }

--- a/windows/Tests/IntergrationTests.swift
+++ b/windows/Tests/IntergrationTests.swift
@@ -168,7 +168,7 @@ func runIntergration(
 
   for filePermission in filePermissions {
     try setAccess(
-      filePermission.path, appContainer: container,
+      filePermission.path, trustee: container,
       accessMode: filePermission.accessMode,
       accessPermissions: filePermission.accessPermissions)
   }
@@ -186,15 +186,15 @@ func runIntergration(
 
   // Grant access to the test executable, hook dll and swift binaries
   try grantAccess(
-    testExecutable, appContainer: container,
+    testExecutable, trustee: container,
     accessPermissions: [.genericRead, .genericExecute])
   try grantAccess(
-    hookDll, appContainer: container,
+    hookDll, trustee: container,
     accessPermissions: [.genericRead, .genericExecute])
 
   for dll in swiftDllPaths {
     try grantAccess(
-      dll, appContainer: container,
+      dll, trustee: container,
       accessPermissions: [.genericRead, .genericExecute])
   }
 
@@ -202,7 +202,7 @@ func runIntergration(
 
   if let namedPipe = namedPipe {
     try grantNamedPipeAccess(
-      pipe: namedPipe, appContainer: container, accessPermissions: [.genericRead, .genericWrite])
+      pipe: namedPipe, trustee: container, accessPermissions: [.genericRead, .genericWrite])
     if namedPipe is SandboxNamedPipeServer {
       commandLine.append("-Dsandbox.namedPipe=\(namedPipe.path)")
     }

--- a/windows/Tests/IntergrationTests.swift
+++ b/windows/Tests/IntergrationTests.swift
@@ -201,8 +201,8 @@ func runIntergration(
   var commandLine = [testExecutable.path()] + args
 
   if let namedPipe = namedPipe {
-    try grantNamedPipeAccess(
-      pipe: namedPipe, trustee: container, accessPermissions: [.genericRead, .genericWrite])
+    try grantAccess(
+      namedPipe, trustee: container, accessPermissions: [.genericRead, .genericWrite])
     if namedPipe is SandboxNamedPipeServer {
       commandLine.append("-Dsandbox.namedPipe=\(namedPipe.path)")
     }

--- a/windows/Tests/JavaTests.swift
+++ b/windows/Tests/JavaTests.swift
@@ -96,14 +96,14 @@ private func runJava(_ source: String) throws -> String {
   }
 
   try grantAccess(
-    javaHome, appContainer: container, accessPermissions: [.genericRead, .genericExecute])
+    javaHome, trustee: container, accessPermissions: [.genericRead, .genericExecute])
   try grantAccess(
-    File(mountedDisk.drivePath), appContainer: container, accessPermissions: [.genericAll])
+    File(mountedDisk.drivePath), trustee: container, accessPermissions: [.genericAll])
   try grantAccess(
-    try getModuleFileName().parent()!, appContainer: container,
+    try getModuleFileName().parent()!, trustee: container,
     accessPermissions: [.genericRead, .genericExecute])
   try grantAccess(
-    try findSwiftRuntimeDirectory(), appContainer: container,
+    try findSwiftRuntimeDirectory(), trustee: container,
     accessPermissions: [.genericRead, .genericExecute])
 
   let outputConsumer = TestOutputConsumer()


### PR DESCRIPTION
- Abstract away the trustee type, named pipes and files share the same code now.
- Supporting removing ACE's with arbitrary SIDs.
- Add some basic tests