### PR TITLE
Grant access to Discord RPC named pipes.

### DIFF
--- a/windows/Sources/FabricSandbox/DiscordPipeSupport.swift
+++ b/windows/Sources/FabricSandbox/DiscordPipeSupport.swift
@@ -17,6 +17,8 @@ public func grantAccessToDiscordPipes(trustee: Trustee) throws {
             continue
         }
 
+        logger.info("Granting access to Discord named pipe: \(pipe.path)")
+
         // Remove any existing ACEs for the trustee and then grant full access
         // Ensure we only modify the DACL if the trustee doesn't already have access, to avoid breaking an existing connection
         var hasEntry = try hasAceEntry(pipe, trustee: trustee)

--- a/windows/Sources/FabricSandbox/FabricSandbox.swift
+++ b/windows/Sources/FabricSandbox/FabricSandbox.swift
@@ -153,6 +153,10 @@ class FabricSandbox {
       namedPipeServer, trustee: container,
       accessPermissions: [.genericRead, .genericWrite])
 
+    // Grant access to any of the active discord named pipes
+    // TODO we might want to run this every so often to handle new pipes
+    try grantAccessToDiscordPipes(trustee: container)
+
     let args = try commandLine.getSandboxArgs(
       dotMinecraftDir: dotMinecraft, sandboxRoot: sandboxRoot, namedPipePath: namedPipeServer.path)
 

--- a/windows/Sources/FabricSandbox/FabricSandbox.swift
+++ b/windows/Sources/FabricSandbox/FabricSandbox.swift
@@ -148,10 +148,7 @@ class FabricSandbox {
     let namedPipeServer = try SandboxNamedPipeServer(
       pipeName: "\\\\.\\pipe\\FabricSandbox" + randomString(length: 10))
 
-    // Grant access to the named pipe
-    try grantAccess(
-      namedPipeServer, trustee: container,
-      accessPermissions: [.genericRead, .genericWrite])
+    logger.debug("Named pipe: \(namedPipeServer.path)")
 
     // Grant access to any of the active discord named pipes
     // TODO we might want to run this every so often to handle new pipes

--- a/windows/Sources/Sandbox/DiscordPipeSupport.swift
+++ b/windows/Sources/Sandbox/DiscordPipeSupport.swift
@@ -1,0 +1,27 @@
+import WindowsUtils
+import WinSDK
+
+// https://github.com/discord/discord-rpc/blob/master/documentation/hard-mode.md
+// https://github.com/discord/discord-rpc/blob/963aa9f3e5ce81a4682c6ca3d136cddda614db33/src/connection_win.cpp#L35C26-L35C52
+fileprivate var PIPE_BASE_NAME = "\\\\?\\pipe\\discord-ipc-" // 0-9 suffix
+
+// Grant access to any of the running Discord pipes
+public func grantAccessToDiscordPipes(trustee: Trustee) throws {
+    for i in 0..<10 {
+        let pipe = try? NamedPipeClient(
+            pipeName: "\(PIPE_BASE_NAME)\(i)",
+            desiredAccess: DWORD(READ_CONTROL | WRITE_DAC), // We only need to open the pipe to set the DACL
+            mode: nil
+        )
+        guard let pipe = pipe else {
+            continue
+        }
+
+        // Remove any existing ACEs for the trustee and then grant full access
+        // Ensure we only modify the DACL if the trustee doesn't already have access, to avoid breaking an existing connection
+        var hasEntry = try hasAceEntry(pipe, trustee: trustee)
+        if !hasEntry {
+            try grantAccess(pipe, trustee: trustee, accessPermissions: [.genericAll])
+        }
+    }
+}

--- a/windows/Sources/WindowsUtils/NamedPipe.swift
+++ b/windows/Sources/WindowsUtils/NamedPipe.swift
@@ -34,7 +34,8 @@ open class NamedPipeServer: Thread, NamedPipe {
     }
 
     var securityAttributesValue = SECURITY_ATTRIBUTES(
-      nLength: DWORD(MemoryLayout<SECURITY_ATTRIBUTES>.size), lpSecurityDescriptor: security,
+      nLength: DWORD(MemoryLayout<SECURITY_ATTRIBUTES>.size),
+      lpSecurityDescriptor: security,
       bInheritHandle: false)
 
     let pipe = CreateNamedPipeW(

--- a/windows/Tests/AclTests.swift
+++ b/windows/Tests/AclTests.swift
@@ -14,25 +14,30 @@ struct AclTests {
 
     var sddl = try getStringSecurityDescriptor(tempDir)
     #expect(!sddl.contains(";\(sid)"))
+    #expect(!(try hasAceEntry(tempDir, trustee: trustee)))
 
     try grantAccess(tempDir, trustee: trustee, accessPermissions: [.genericAll])
     sddl = try getStringSecurityDescriptor(tempDir)
     // Allow full access
     #expect(sddl.contains("A;;FA;;;\(sid)"))
+    #expect(try hasAceEntry(tempDir, trustee: trustee))
 
     try clearAccess(tempDir, trustee: trustee)
     sddl = try getStringSecurityDescriptor(tempDir)
     #expect(!sddl.contains(";\(sid)"))
+    #expect(!(try hasAceEntry(tempDir, trustee: trustee)))
 
     try denyAccess(tempDir, trustee: trustee, accessPermissions: [.genericExecute])
     sddl = try getStringSecurityDescriptor(tempDir)
     // Deny execute
     #expect(sddl.contains("D;;FX;;;\(sid)"))
+    #expect(try hasAceEntry(tempDir, trustee: trustee))
 
     // Test that we can remove mutlipe ACEs
     try grantAccess(tempDir, trustee: trustee, accessPermissions: [.genericRead])
     try clearAccess(tempDir, trustee: trustee)
     sddl = try getStringSecurityDescriptor(tempDir)
     #expect(!sddl.contains(";\(sid)"))
+    #expect(!(try hasAceEntry(tempDir, trustee: trustee)))
   }
 }

--- a/windows/Tests/IntergrationTests.swift
+++ b/windows/Tests/IntergrationTests.swift
@@ -201,8 +201,6 @@ func runIntergration(
   var commandLine = [testExecutable.path()] + args
 
   if let namedPipe = namedPipe {
-    try grantAccess(
-      namedPipe, trustee: container, accessPermissions: [.genericRead, .genericWrite])
     if namedPipe is SandboxNamedPipeServer {
       commandLine.append("-Dsandbox.namedPipe=\(namedPipe.path)")
     }


### PR DESCRIPTION
This allows mods that use Discord RPC to work within the sandbox without any changes. Currently might not work if you open discord after the game.

Closes #16

![image](https://github.com/user-attachments/assets/44ef5e63-2d13-4095-a0e7-ae59c8e8ddd7)
