### PR TITLE
Access token protection proof of concept

### DIFF
--- a/authproxy/build.gradle
+++ b/authproxy/build.gradle
@@ -10,6 +10,8 @@ repositories {
 }
 
 dependencies {
+    compileOnly 'org.slf4j:slf4j-api:2.0.16'
+
     testImplementation "com.mojang:authlib:6.0.57"
     testImplementation 'io.javalin:javalin:6.3.0'
     testImplementation 'org.slf4j:slf4j-simple:2.0.16'

--- a/authproxy/build.gradle
+++ b/authproxy/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id 'java-library'
+}
+
+repositories {
+    mavenCentral()
+    maven {
+        url = "https://libraries.minecraft.net/"
+    }
+}
+
+dependencies {
+    testImplementation "com.mojang:authlib:6.0.57"
+    testImplementation 'io.javalin:javalin:6.3.0'
+    testImplementation 'org.slf4j:slf4j-simple:2.0.16'
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.11.3"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.11.3"
+}
+
+test {
+    useJUnitPlatform()
+}
+
+tasks.withType(JavaCompile).configureEach {
+    it.options.release = 17
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}

--- a/authproxy/src/main/java/net/fabricmc/sandbox/authproxy/AccessToken.java
+++ b/authproxy/src/main/java/net/fabricmc/sandbox/authproxy/AccessToken.java
@@ -1,0 +1,17 @@
+package net.fabricmc.sandbox.authproxy;
+
+public record AccessToken(String realAccessToken, String sandboxToken) {
+    public RequestProcessor.Header rewriteHeader(RequestProcessor.Header header) {
+        if (header.key().equals("Authorization") && header.value().startsWith("Bearer ")) {
+            String value = header.value();
+
+            if (sandboxToken.equals(value.substring(7))) {
+                return new RequestProcessor.Header("Authorization", "Bearer " + realAccessToken);
+            }
+
+            return header;
+        }
+
+        return header;
+    }
+}

--- a/authproxy/src/main/java/net/fabricmc/sandbox/authproxy/AuthProxy.java
+++ b/authproxy/src/main/java/net/fabricmc/sandbox/authproxy/AuthProxy.java
@@ -1,0 +1,117 @@
+package net.fabricmc.sandbox.authproxy;
+
+import com.sun.net.httpserver.HttpExchange;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.http.HttpClient;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class AuthProxy implements RequestProcessor, AutoCloseable {
+    private static final String SESSION_HOST = "https://sessionserver.mojang.com";
+    private static final String SESSION_PATH = "/session";
+    private static final String SESSION_SYSTEM_PROPERTY = "minecraft.api.session.host";
+
+    private static final String SERVICES_HOST = "https://api.minecraftservices.com";
+    private static final String SERVICES_PATH = "/api";
+    private static final String SERVICES_SYSTEM_PROPERTY = "minecraft.api.services.host";
+
+    private static final List<String> IGNORED_HEADERS = List.of("Connection", "Host", "Content-length");
+
+    private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+
+    private final int port;
+    private final AccessToken accessToken;
+    private final AuthProxyServer server;
+
+    private AuthProxy(int port, AccessToken accessToken, String sessionHost, String servicesHost) throws IOException {
+        this.port = port;
+        this.accessToken = accessToken;
+        this.server = AuthProxyServer.create(port, Map.of(
+                SESSION_PATH, new ProxyHttpHandler(this, SESSION_PATH, sessionHost, HTTP_CLIENT),
+                SERVICES_PATH, new ProxyHttpHandler(this, SERVICES_PATH, servicesHost, HTTP_CLIENT)
+        ));
+        this.server.start();
+    }
+
+    public static AuthProxy create(int port, AccessToken accessToken) throws IOException {
+        return create(port, accessToken, SESSION_HOST, SERVICES_HOST);
+    }
+
+    public static AuthProxy create(int port, AccessToken accessToken, String sessionHost, String servicesHost) throws IOException {
+        return new AuthProxy(port, accessToken, sessionHost, servicesHost);
+    }
+
+    private String getProxyHost() {
+        return "http://localhost:" + port;
+    }
+
+    public String getSessionProxyAddress() {
+        return getProxyHost() + SESSION_PATH;
+    }
+
+    public String getApiProxyAddress() {
+        return getProxyHost() + SERVICES_PATH;
+    }
+
+    public Map<String, String> getSystemProperties() {
+        return Map.of(
+            SESSION_SYSTEM_PROPERTY, getSessionProxyAddress(),
+            SERVICES_SYSTEM_PROPERTY, getApiProxyAddress()
+        );
+    }
+
+    // The list of arguments to pass to the Minecraft game to configure it to use the proxy
+    public List<String> getArguments() {
+        return List.of(
+            "-D" + SESSION_SYSTEM_PROPERTY + "=" + getSessionProxyAddress(),
+            "-D" + SERVICES_SYSTEM_PROPERTY + "=" + getApiProxyAddress()
+        );
+    }
+
+    @Override
+    public void close() throws Exception {
+        server.close();
+    }
+
+    @Override
+    public Request process(HttpExchange exchange) {
+        return new Request() {
+            @Override
+            public String path() {
+                return exchange.getRequestURI().getPath();
+            }
+
+            @Override
+            public String method() {
+                return exchange.getRequestMethod();
+            }
+
+            @Override
+            public Header[] headers() {
+                Header[] headers = Header.of(exchange.getRequestHeaders());
+                return Arrays.stream(headers)
+                        .filter(header -> !IGNORED_HEADERS.contains(header.key()))
+                        .map(accessToken::rewriteHeader)
+                        .toArray(Header[]::new);
+            }
+
+            @Override
+            public byte[] body() throws IOException {
+                byte[] body;
+
+                try (InputStream is = exchange.getRequestBody()) {
+                    body = is.readAllBytes();
+                }
+
+                if (body.length == 0) {
+                    return null;
+                }
+
+                return body;
+            }
+        };
+    }
+}

--- a/authproxy/src/main/java/net/fabricmc/sandbox/authproxy/AuthProxy.java
+++ b/authproxy/src/main/java/net/fabricmc/sandbox/authproxy/AuthProxy.java
@@ -36,6 +36,10 @@ public class AuthProxy implements RequestProcessor, AutoCloseable {
         this.server.start();
     }
 
+    public static AuthProxy create(int port, String realAccessToken, String sandboxToken) throws IOException {
+        return create(port, new AccessToken(realAccessToken, sandboxToken));
+    }
+
     public static AuthProxy create(int port, AccessToken accessToken) throws IOException {
         return create(port, accessToken, SESSION_HOST, SERVICES_HOST);
     }
@@ -64,11 +68,11 @@ public class AuthProxy implements RequestProcessor, AutoCloseable {
     }
 
     // The list of arguments to pass to the Minecraft game to configure it to use the proxy
-    public List<String> getArguments() {
-        return List.of(
+    public String[] getArguments() {
+        return new String[] {
             "-D" + SESSION_SYSTEM_PROPERTY + "=" + getSessionProxyAddress(),
             "-D" + SERVICES_SYSTEM_PROPERTY + "=" + getApiProxyAddress()
-        );
+        };
     }
 
     @Override

--- a/authproxy/src/main/java/net/fabricmc/sandbox/authproxy/AuthProxy.java
+++ b/authproxy/src/main/java/net/fabricmc/sandbox/authproxy/AuthProxy.java
@@ -5,6 +5,7 @@ import com.sun.net.httpserver.HttpExchange;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -81,7 +82,7 @@ public class AuthProxy implements RequestProcessor, AutoCloseable {
     }
 
     @Override
-    public Request process(HttpExchange exchange) {
+    public Request process(HttpExchange exchange, byte[] body) {
         return new Request() {
             @Override
             public String path() {
@@ -103,15 +104,11 @@ public class AuthProxy implements RequestProcessor, AutoCloseable {
             }
 
             @Override
-            public byte[] body() throws IOException {
-                byte[] body;
-
-                try (InputStream is = exchange.getRequestBody()) {
-                    body = is.readAllBytes();
-                }
-
-                if (body.length == 0) {
-                    return null;
+            public byte[] body() {
+                if ("/session/session/minecraft/join".equals(path())) {
+                    String str = new String(body, StandardCharsets.UTF_8);
+                    str = str.replace(accessToken.sandboxToken(), accessToken.realAccessToken());
+                    return str.getBytes(StandardCharsets.UTF_8);
                 }
 
                 return body;

--- a/authproxy/src/main/java/net/fabricmc/sandbox/authproxy/AuthProxyServer.java
+++ b/authproxy/src/main/java/net/fabricmc/sandbox/authproxy/AuthProxyServer.java
@@ -1,0 +1,34 @@
+package net.fabricmc.sandbox.authproxy;
+
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Map;
+
+public class AuthProxyServer implements AutoCloseable {
+    private static final int BACKLOG = 8;
+
+    private final HttpServer server;
+
+    private AuthProxyServer(HttpServer server) {
+        this.server = server;
+    }
+
+    public static AuthProxyServer create(int port, Map<String, ProxyHttpHandler> handlers) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress(port), BACKLOG);
+        AuthProxyServer authProxyServer = new AuthProxyServer(server);
+        handlers.forEach(server::createContext);
+        server.setExecutor(null); // TODO might want to use a thread pool?
+        return authProxyServer;
+    }
+
+    public void start() {
+        server.start();
+    }
+
+    @Override
+    public void close() throws Exception {
+        server.stop(0);
+    }
+}

--- a/authproxy/src/main/java/net/fabricmc/sandbox/authproxy/ProxyHttpHandler.java
+++ b/authproxy/src/main/java/net/fabricmc/sandbox/authproxy/ProxyHttpHandler.java
@@ -1,0 +1,75 @@
+package net.fabricmc.sandbox.authproxy;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public class ProxyHttpHandler implements HttpHandler {
+    private final RequestProcessor requestProcessor;
+    private final String pathPrefix;
+    private final String proxyHost;
+    private final HttpClient httpClient;
+
+    public ProxyHttpHandler(RequestProcessor requestProcessor, String pathPrefix, String proxyHost, HttpClient httpClient) {
+        this.requestProcessor = requestProcessor;
+        this.pathPrefix = pathPrefix;
+
+        if (!proxyHost.startsWith("http://")  && !proxyHost.startsWith("https://")) {
+            throw new IllegalArgumentException("Invalid proxy host: " + proxyHost);
+        }
+
+        this.proxyHost = proxyHost;
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        try {
+            handleInternal(exchange);
+        } catch (Exception e) {
+//            e.printStackTrace();
+            exchange.sendResponseHeaders(500, 0);
+        } finally {
+            exchange.close();
+        }
+    }
+
+    private void handleInternal(HttpExchange exchange) throws IOException {
+        RequestProcessor.Request request = requestProcessor.process(exchange);
+
+        String path = request.path();
+        if (!path.startsWith(pathPrefix)) {
+            exchange.sendResponseHeaders(400, 0);
+            return;
+        }
+
+        String pathWithoutPrefix = path.substring(pathPrefix.length());
+        URI proxyUri = URI.create(proxyHost + pathWithoutPrefix);
+
+        byte[] body = request.body();
+
+        HttpRequest.Builder proxyRequest = HttpRequest.newBuilder()
+                .uri(proxyUri)
+                .method(request.method(), body != null ? HttpRequest.BodyPublishers.ofByteArray(body) : HttpRequest.BodyPublishers.noBody())
+                .headers(RequestProcessor.Header.toPairs(request.headers()));
+
+        HttpResponse<byte[]> response;
+
+        try {
+            response = httpClient.send(proxyRequest.build(), HttpResponse.BodyHandlers.ofByteArray());
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        exchange.sendResponseHeaders(response.statusCode(), response.body().length);
+
+        if (response.body().length > 0) {
+            exchange.getResponseBody().write(response.body());
+        }
+    }
+}

--- a/authproxy/src/main/java/net/fabricmc/sandbox/authproxy/RequestProcessor.java
+++ b/authproxy/src/main/java/net/fabricmc/sandbox/authproxy/RequestProcessor.java
@@ -1,0 +1,36 @@
+package net.fabricmc.sandbox.authproxy;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+public interface RequestProcessor {
+    Request process(HttpExchange exchange);
+
+    interface Request {
+        String path();
+
+        String method();
+
+        Header[] headers();
+
+        byte[] body() throws IOException;
+    }
+
+    record Header(String key, String value) {
+        public static Header[] of(Headers headers) {
+            return headers.entrySet().stream()
+                    .flatMap(entry -> entry.getValue().stream().map(value -> new Header(entry.getKey(), value)))
+                    .toArray(Header[]::new);
+        }
+
+        // Header key value pairs
+        public static String[] toPairs(Header[] headers) {
+            return java.util.Arrays.stream(headers)
+                    .flatMap(header -> Stream.of(header.key(), header.value()))
+                    .toArray(String[]::new);
+        }
+    }
+}

--- a/authproxy/src/main/java/net/fabricmc/sandbox/authproxy/RequestProcessor.java
+++ b/authproxy/src/main/java/net/fabricmc/sandbox/authproxy/RequestProcessor.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import java.util.stream.Stream;
 
 public interface RequestProcessor {
-    Request process(HttpExchange exchange);
+    Request process(HttpExchange exchange, byte[] body);
 
     interface Request {
         String path();
@@ -16,7 +16,7 @@ public interface RequestProcessor {
 
         Header[] headers();
 
-        byte[] body() throws IOException;
+        byte[] body();
     }
 
     record Header(String key, String value) {

--- a/authproxy/src/test/java/net/fabricmc/sandbox/authproxy/test/AuthProxyTest.java
+++ b/authproxy/src/test/java/net/fabricmc/sandbox/authproxy/test/AuthProxyTest.java
@@ -1,0 +1,80 @@
+package net.fabricmc.sandbox.authproxy.test;
+
+import com.mojang.authlib.Environment;
+import com.mojang.authlib.EnvironmentParser;
+import com.mojang.authlib.HttpAuthenticationService;
+import com.mojang.authlib.minecraft.client.MinecraftClient;
+import io.javalin.Javalin;
+import net.fabricmc.sandbox.authproxy.AccessToken;
+import net.fabricmc.sandbox.authproxy.AuthProxy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.Proxy;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AuthProxyTest {
+    private static final AccessToken ACCESS_TOKEN = new AccessToken("6e5fc4e4-efa7-48e8-8837-ee658dad7f27", "00000000-0000-0000-0000-000000000000");
+
+    protected Javalin javalin;
+    protected AuthProxy authProxy;
+    protected Environment environment;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        javalin = Javalin.create().start(8081);
+        String javalinHost = "http://localhost:" + javalin.port();
+        authProxy = AuthProxy.create(8080, ACCESS_TOKEN, javalinHost, javalinHost);
+        authProxy.getSystemProperties().forEach(System::setProperty);
+        environment = EnvironmentParser.getEnvironmentFromProperties().orElseThrow();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        javalin.stop();
+        authProxy.close();
+    }
+
+    @Test
+    void getWithValidAccessToken() {
+        MinecraftClient client = new MinecraftClient(ACCESS_TOKEN.sandboxToken(), Proxy.NO_PROXY);
+
+        javalin.get("/test1", ctx -> {
+            assertEquals("Bearer " + ACCESS_TOKEN.realAccessToken(), ctx.header("Authorization"));
+            ctx.status(200);
+        });
+
+        client.get(HttpAuthenticationService.constantURL(environment.servicesHost() + "/test1"), Void.class);
+    }
+
+    @Test
+    void postWithBody() {
+        MinecraftClient client = new MinecraftClient(ACCESS_TOKEN.sandboxToken(), Proxy.NO_PROXY);
+
+        javalin.post("/test2", ctx -> {
+            assertEquals("Bearer " + ACCESS_TOKEN.realAccessToken(), ctx.header("Authorization"));
+            String body = ctx.body().toUpperCase(Locale.ROOT);
+            ctx.status(200);
+            ctx.result(body);
+        });
+
+        String result = client.post(HttpAuthenticationService.constantURL(environment.servicesHost() + "/test2"), "hello world", String.class);
+        assertEquals("HELLO WORLD", result);
+    }
+
+    @Test
+    void forwardsUnknownTokens() {
+        MinecraftClient client = new MinecraftClient("unknown", Proxy.NO_PROXY);
+
+        javalin.get("/test3", ctx -> {
+            assertEquals("Bearer unknown", ctx.header("Authorization"));
+            ctx.status(200);
+        });
+
+        client.get(HttpAuthenticationService.constantURL(environment.servicesHost() + "/test3"), Void.class);
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,21 @@ java {
 	targetCompatibility = JavaVersion.VERSION_17
 }
 
+configurations {
+	authProxy
+}
+
+dependencies {
+	authProxy project(":authproxy")
+}
+
+jar {
+	inputs.files configurations.authProxy
+	from {
+		configurations.authProxy.collect { it.isDirectory() ? it : zipTree(it) }
+	}
+}
+
 evaluationDependsOn(":windows")
 
 def archs = [

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,12 +1,2 @@
-pluginManagement {
-	repositories {
-		maven {
-			name = 'Fabric'
-			url = 'https://maven.fabricmc.net/'
-		}
-		mavenCentral()
-		gradlePluginPortal()
-	}
-}
-
 include "windows"
+include "authproxy"

--- a/windows/Package.swift
+++ b/windows/Package.swift
@@ -63,7 +63,7 @@ let package = Package(
         // The Minecraft/Fabric specific parts of the sandbox
         .target(
             name: "FabricSandbox",
-            dependencies: [ .target(name: "Jni"), .target(name: "WinSDKExtras"), .target(name: "WindowsUtils"), .target(name: "Sandbox"), .product(name: "Logging", package: "swift-log")],
+            dependencies: [ .target(name: "Jni"), .target(name: "WinSDKExtras"), .target(name: "WindowsUtils"), .target(name: "Sandbox"), .target(name: "AuthProxy"), .product(name: "Logging", package: "swift-log")],
             swiftSettings: [.interoperabilityMode(.Cxx)],
             linkerSettings: linkerSettings
         ),
@@ -78,6 +78,11 @@ let package = Package(
         .target(
             name: "Hook",
             dependencies: [ .target(name: "Runtime"), .product(name: "Detours", package: "Detours")],
+            swiftSettings: [.interoperabilityMode(.Cxx)]
+        ),
+        .target(
+            name: "AuthProxy",
+            dependencies: [ .target(name: "Jni") ],
             swiftSettings: [.interoperabilityMode(.Cxx)]
         ),
         // Packager to copy all the required files into a single directory

--- a/windows/Sources/AuthProxy/AuthProxy.swift
+++ b/windows/Sources/AuthProxy/AuthProxy.swift
@@ -1,0 +1,95 @@
+import Jni
+
+public class AuthProxy {
+    private let jni: JNIEnvPtr
+    private let claszz: jclass
+    private let object: jobject
+
+    private init(jni: JNIEnvPtr, claszz: jclass, object: jobject) {
+        self.jni = jni
+        self.claszz = claszz
+        self.object = object
+    }
+
+    deinit {
+        try? close()
+        claszz.withMemoryRebound(to: jobject.self, capacity: 1) {
+            jni.pointee.DeleteLocalRef($0.pointee)
+        }
+    }
+
+    // public static AuthProxy create(int port, String realAccessToken, String sandboxToken) throws IOException {
+    public static func create(_ jni: JNIEnvPtr, port: Int32, realAccessToken: String, sandboxToken: String) throws -> AuthProxy {
+        let clazz = try jni.getClass("net/fabricmc/sandbox/authproxy/AuthProxy")
+
+        let method = jni.pointee.GetStaticMethodID(clazz, "create", "(ILjava/lang/String;Ljava/lang/String;)Lnet/fabricmc/sandbox/authproxy/AuthProxy;")
+        guard let method = method else {
+            throw JavaError.jni("Failed to find method")
+        }
+
+        let realAccessToken = try JString(jni, string: realAccessToken)
+        let sandboxToken = try JString(jni, string: sandboxToken)
+
+        let object = withVaList([port, realAccessToken.jstr, sandboxToken.jstr]) {
+            jni.pointee.CallStaticObjectMethodV(clazz, method, $0)
+        }
+        guard let object = object else {
+            throw JavaError.jni("Failed to create object")
+        }
+        try jni.checkException()
+
+        return AuthProxy(jni: jni, claszz: clazz, object: object)
+    }
+
+    // String[] getArguments()
+    public func getArguments() throws -> [String] {
+        let method = jni.pointee.GetMethodID(claszz, "getArguments", "()[Ljava/lang/String;")
+        guard let method = method else {
+            throw JavaError.jni("Failed to find method")
+        }
+
+        let array = withVaList([]) {
+            jni.pointee.CallObjectMethodV(object, method, $0)
+        }
+        guard let array = array else {
+            throw JavaError.jni("Failed to get return value")
+        }
+
+        let length = array.withMemoryRebound(to: jarray.self, capacity: 1) { array in
+            jni.pointee.GetArrayLength(array.pointee)
+        }
+
+        return try array.withMemoryRebound(to: jobjectArray.self, capacity: 1) { array in
+            try (1...length).map { index in
+                let element = jni.pointee.GetObjectArrayElement(array.pointee, index)
+                guard let element = element else {
+                    throw JavaError.jni("Failed to get array element")
+                }
+
+                return try element.withMemoryRebound(to: jstring.self, capacity: 1) { string in
+                    let cString = jni.pointee.GetStringUTFChars(string.pointee, nil)
+                    guard let cString = cString else {
+                        throw JavaError.jni("Failed to get string")
+                    }
+                    defer {
+                        jni.pointee.ReleaseStringUTFChars(string.pointee, cString)
+                    }
+
+                    return String(cString: cString)
+                }
+            }
+        }
+    }
+
+    func close() throws {
+        let method = jni.pointee.GetMethodID(claszz, "close", "()V")
+        guard let method = method else {
+            throw JavaError.jni("Failed to find method")
+        }
+
+        withVaList([]) {
+            jni.pointee.CallVoidMethodV(object, method, $0)
+        }
+        try jni.checkException()
+    }
+}

--- a/windows/Sources/AuthProxy/AuthProxy.swift
+++ b/windows/Sources/AuthProxy/AuthProxy.swift
@@ -55,24 +55,26 @@ public class AuthProxy {
             throw JavaError.jni("Failed to get return value")
         }
 
-        let length = array.withMemoryRebound(to: jarray.self, capacity: 1) { array in
-            jni.pointee.GetArrayLength(array.pointee)
+        let length = array.withMemoryRebound(to: _jarray.self, capacity: 1) { array in
+            jni.pointee.GetArrayLength(array)
         }
 
         return try array.withMemoryRebound(to: jobjectArray.self, capacity: 1) { array in
-            try (1...length).map { index in
-                let element = jni.pointee.GetObjectArrayElement(array.pointee, index)
+            try (0..<length).map { index in
+                let element = array.withMemoryRebound(to: _jobjectArray.self, capacity: 1) { array in
+                    jni.pointee.GetObjectArrayElement(array, index)
+                }
                 guard let element = element else {
                     throw JavaError.jni("Failed to get array element")
                 }
 
-                return try element.withMemoryRebound(to: jstring.self, capacity: 1) { string in
-                    let cString = jni.pointee.GetStringUTFChars(string.pointee, nil)
+                return try element.withMemoryRebound(to: _jstring.self, capacity: 1) { string in
+                    let cString = jni.pointee.GetStringUTFChars(string, nil)
                     guard let cString = cString else {
                         throw JavaError.jni("Failed to get string")
                     }
                     defer {
-                        jni.pointee.ReleaseStringUTFChars(string.pointee, cString)
+                        jni.pointee.ReleaseStringUTFChars(string, cString)
                     }
 
                     return String(cString: cString)

--- a/windows/Sources/AuthProxy/JniHelpers.swift
+++ b/windows/Sources/AuthProxy/JniHelpers.swift
@@ -35,8 +35,8 @@ public class JString {
     }
 
     deinit {
-        jstr.withMemoryRebound(to: jobject.self, capacity: 1) {
-            jni.pointee.DeleteLocalRef($0.pointee)
+        jstr.withMemoryRebound(to: _jobject.self, capacity: 1) {
+            jni.pointee.DeleteLocalRef($0)
         }
     }
 }

--- a/windows/Sources/AuthProxy/JniHelpers.swift
+++ b/windows/Sources/AuthProxy/JniHelpers.swift
@@ -1,0 +1,47 @@
+import Jni
+
+public typealias JNIEnvPtr = UnsafeMutablePointer<JNIEnv>
+
+extension JNIEnvPtr {
+    public func getClass(_ name: String) throws -> jclass {
+        let clazz = self.pointee.FindClass(name)
+        guard let clazz = clazz else {
+            throw JavaError.jni("Failed to find class: \(name)")
+        }
+        return clazz
+    }
+
+    public func checkException() throws {
+        if self.pointee.ExceptionCheck() == JNI_TRUE {
+            self.pointee.ExceptionDescribe()
+            self.pointee.ExceptionClear() // Clear the exception so we can call other JNI functions
+            throw JavaError.exception("Java exception")
+        }
+    }
+}
+
+public class JString {
+    let jni: UnsafeMutablePointer<JNIEnv>
+    let jstr: jstring
+
+    init(_ jni: UnsafeMutablePointer<JNIEnv>, string: String) throws {
+        let jstr = jni.pointee.NewStringUTF(string)
+        guard let jstr = jstr else {
+            throw JavaError.jni("Failed to create string")
+        }
+
+        self.jni = jni
+        self.jstr = jstr
+    }
+
+    deinit {
+        jstr.withMemoryRebound(to: jobject.self, capacity: 1) {
+            jni.pointee.DeleteLocalRef($0.pointee)
+        }
+    }
+}
+
+public enum JavaError: Error {
+    case exception(String)
+    case jni(String)
+}

--- a/windows/Sources/FabricSandbox/FabricSandbox.swift
+++ b/windows/Sources/FabricSandbox/FabricSandbox.swift
@@ -8,7 +8,7 @@ import AuthProxy
 /// TODO: Add support for LPAC (Less Privileged AppContainer)
 
 private let lpac = false
-private let useAuthProxy = true
+private let useAuthProxy = false
 
 var logger = Logger(label: "net.fabricmc.sandbox")
 

--- a/windows/Sources/FabricSandbox/FabricSandbox.swift
+++ b/windows/Sources/FabricSandbox/FabricSandbox.swift
@@ -165,22 +165,26 @@ class FabricSandbox {
     // TODO we might want to run this every so often to handle new pipes
     try grantAccessToDiscordPipes(trustee: container)
 
+    let realAccessToken = commandLine.getAccessToken()
     var authProxy: AuthProxy? = nil
+    var sandboxToken: String? = nil
 
-    if useAuthProxy {
+    if useAuthProxy, let realAccessToken = realAccessToken {
       guard let jni = jni else {
         throw SandboxError("AuthProxy requires JNIEnv")
       }
 
       logger.info("AuthProxy enabled")
-      authProxy = try AuthProxy.create(jni, port: 8080, realAccessToken: "real", sandboxToken: "sandbox")
+      sandboxToken = try generateUUID()
+      authProxy = try AuthProxy.create(jni, port: 8080, realAccessToken: realAccessToken, sandboxToken: sandboxToken!)
     }
 
     let args = try commandLine.getSandboxArgs(
       dotMinecraftDir: dotMinecraft,
       sandboxRoot: sandboxRoot,
       namedPipePath: namedPipeServer.path,
-      extraJvmArgs: authProxy?.getArguments() ?? [])
+      extraJvmArgs: authProxy?.getArguments() ?? [],
+      replaceAccessToken: sandboxToken)
 
     logger.debug("Args: \(args)")
 

--- a/windows/Sources/FabricSandbox/JniEntrypoint.swift
+++ b/windows/Sources/FabricSandbox/JniEntrypoint.swift
@@ -4,7 +4,7 @@ import WinSDK
 @_cdecl("Java_net_fabricmc_sandbox_Main_nativeEntrypoint")
 public func entrypoint(jni: UnsafeMutablePointer<JNIEnv>, clazz: jclass!) {
   do {
-    try FabricSandbox().run()
+    try FabricSandbox().run(jni: jni)
   } catch {
     let runtimeException = jni.pointee.FindClass("java/lang/RuntimeException")!
     let _ = jni.pointee.ThrowNew(runtimeException, "\(error)")

--- a/windows/Sources/FabricSandbox/SandboxCommandLine.swift
+++ b/windows/Sources/FabricSandbox/SandboxCommandLine.swift
@@ -86,8 +86,16 @@ class SandboxCommandLine {
     return File(args[index + 1])
   }
 
+  func getAccessToken() -> String? {
+    let accessToken = args.firstIndex(of: "--accessToken")
+    guard let index = accessToken, index + 1 < args.count else {
+      return nil
+    }
+    return args[index + 1]
+  }
+
   // Returns the arguments to pass to the sandboxed JVM.
-  func getSandboxArgs(dotMinecraftDir: File, sandboxRoot: File, namedPipePath: String, extraJvmArgs: [String] = []) throws
+  func getSandboxArgs(dotMinecraftDir: File, sandboxRoot: File, namedPipePath: String, extraJvmArgs: [String] = [], replaceAccessToken: String? = nil) throws
     -> [String]
   {
     var args = try getArgsExpandingArgsFiles()
@@ -128,7 +136,9 @@ class SandboxCommandLine {
           // Rewrite the remap classpath file to ensure that all of the entries are within the sandbox.
           let file = File(String(args[i].dropFirst("-Dfabric.remapClasspathFile=".count)))
           args[i] = "-Dfabric.remapClasspathFile=\(try rewriteRemapClasspathFile(file, sandboxRoot: sandboxRoot).path())"
-      }
+      } else if args[i] == "--accessToken", let accessToken = replaceAccessToken {
+          args[i + 1] = accessToken
+      } else
 
       if args[i].starts(with: "-D") && jvmArgsIndex < 0 {
         // Find the first JVM argument, so we can insert our own at the same point.

--- a/windows/Sources/FabricSandbox/SandboxCommandLine.swift
+++ b/windows/Sources/FabricSandbox/SandboxCommandLine.swift
@@ -87,7 +87,7 @@ class SandboxCommandLine {
   }
 
   // Returns the arguments to pass to the sandboxed JVM.
-  func getSandboxArgs(dotMinecraftDir: File, sandboxRoot: File, namedPipePath: String) throws
+  func getSandboxArgs(dotMinecraftDir: File, sandboxRoot: File, namedPipePath: String, extraJvmArgs: [String] = []) throws
     -> [String]
   {
     var args = try getArgsExpandingArgsFiles()
@@ -161,6 +161,8 @@ class SandboxCommandLine {
       }
 
       args.insert("-Dsandbox.namedPipe=\(namedPipePath)", at: jvmArgsIndex)
+
+      args.insert(contentsOf: extraJvmArgs, at: jvmArgsIndex)
 
       // Enable this to debug the sandboxed process, you will need to exempt the sandbox from the loopback networking like so:
       // CheckNetIsolation.exe LoopbackExempt -is -p=<SID>

--- a/windows/Sources/WindowsUtils/UUID.swift
+++ b/windows/Sources/WindowsUtils/UUID.swift
@@ -1,0 +1,20 @@
+import WinSDK
+
+public func generateUUID() throws -> String {
+    var uuid = UUID()
+    var result = UuidCreate(&uuid)
+    guard result == RPC_S_OK else {
+        throw Win32Error("UuidCreate")
+    }
+
+    var rpcStr: RPC_CSTR?
+    result = UuidToStringA(&uuid, &rpcStr)
+    guard result == RPC_S_OK else {
+        throw Win32Error("UuidToStringA")
+    }
+    defer {
+        RpcStringFreeA(&rpcStr)
+    }
+
+    return String(cString: rpcStr!)
+}


### PR DESCRIPTION
A proof of concept for access token protection, this works by proxying all of the auth related APIs via the host process. The game process only has a randomly generated access token that gets replaced by the proxy. Currently disabled as I have not looked at the requests the game makes in deatails to see if its leaked elsewhere, or if there are any other tokens that need to be replaced. I would also like to look at using a self signed SSL cert but as far as I know there isnt a major concern without one.