### PR TITLE
Named pipe improvements

### DIFF
--- a/windows/Sources/Runtime/Runtime.swift
+++ b/windows/Sources/Runtime/Runtime.swift
@@ -66,7 +66,7 @@ func sendMessage(_ message: PipeMessages) {
   }
 
   do {
-    try pipeClient.sendBytes(message.toBytes())
+    let _ = try pipeClient.sendBytes(message.toBytes())
   } catch {
     fatalError("Failed to send pipe message")
   }

--- a/windows/Sources/Sandbox/SandboxNamedPipeServer.swift
+++ b/windows/Sources/Sandbox/SandboxNamedPipeServer.swift
@@ -14,16 +14,16 @@ public class SandboxNamedPipeServer: NamedPipeServer {
     try super.init(pipeName: pipeName, allowedTrustees: allowedTrustees + [TokenUserTrustee()])
   }
 
-  public override func onMessage(_ data: [UInt16]) -> Bool {
+  public override func onMessage(_ data: [UInt16]) -> [UInt16]? {
     let message = PipeMessages.fromBytes(data)
     guard let message = message else {
       print("Failed to parse message")
-      return true
+      return nil
     }
 
     switch message {
     case .exit:
-      return true
+      return nil
     case .clipCursor(let rect):
       if rect.left < 0 && rect.top < 0 && rect.right < 0 && rect.bottom < 0 {
         // Unclip the cursor when the rect is all 0s
@@ -47,7 +47,8 @@ public class SandboxNamedPipeServer: NamedPipeServer {
       }
       speech!.Skip()
     }
-    return false
+
+    return [ 0 ]
   }
 }
 

--- a/windows/Sources/SandboxTest/NamedPipeCommand.swift
+++ b/windows/Sources/SandboxTest/NamedPipeCommand.swift
@@ -5,7 +5,7 @@ class NamedPipeCommand: Command {
     do {
       let name = arguments.first ?? "TestPipe"
       let pipeClient = try NamedPipeClient(pipeName: name)
-      try pipeClient.send("Hello, World!")
+      let _ = try pipeClient.send("Hello, World!")
       print("Sent message to named pipe")
     } catch {
       print("Error: \(error)")

--- a/windows/Sources/WindowsUtils/Mutex.swift
+++ b/windows/Sources/WindowsUtils/Mutex.swift
@@ -1,0 +1,24 @@
+import WinSDK
+
+class Mutex {
+    private let mutex: HANDLE
+    
+    init() {
+        mutex = CreateMutexW(nil, false, nil)
+    }
+    
+    deinit {
+        CloseHandle(mutex)
+    }
+    
+    func wait() throws {
+        let result = WaitForSingleObject(mutex, INFINITE)
+        guard result == WAIT_OBJECT_0 else {
+            throw Win32Error("WaitForSingleObject")
+        }
+    }
+
+    func release() {
+        ReleaseMutex(mutex)
+    }
+}


### PR DESCRIPTION
Make named pipe messages include a request and now response, will be used for 2 way data transfer between the 2 processes.

Only one thread can use the pipe at a time.